### PR TITLE
한글번역 업데이트 / Korean translation update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1335,26 +1335,26 @@
     <string name="draft_feature_slime00_title">슬라임 대재앙</string>
     <string name="draft_feature_slime00_text">슬라임 재앙은 도시의 모든 것을 먹어치울 겁니다. 당현히, 오직 당신이 그것을 하길 바랄 때 만요.</string>
 
-    <string name="settings_terrainshading">Terrain shading</string>
-    <string name="draft_deco_chr_tree00_title">Christmas tree</string>
-    <string name="draft_deco_chr_tree00_text">The Christmas tree will fill the hearts of your inhabitants with joy and glory. Do you see any presents?</string>
-    <string name="draft_jardinehouse00_title">Jardine House</string>
-    <string name="draft_jardinehouse00_text">The Jardine House is a office tower placed in Hong Kong. It has 52 floors and has a height of 179 m. It was completed in 1972.</string>
-    <string name="draft_bankofchina00_title">Bank of China</string>
-    <string name="draft_bankofchina00_text">The Bank of China Tower in Hong Kong houses the headquarters for the Bank of China HK. It has 70 floors, is 367 m high and was finished in 1990.</string>
-    <string name="settings_road_zone_width">Width between zone roads</string>
-    <string name="settings_road_zone_height">Height between zone roads</string>
-    <string name="draft_feature_christmas_pack00_title">Christmas special</string>
-    <string name="draft_feature_christmas_pack00_text">The limited offer contains:</string>
-    <string name="draft_feature_christmas00_title">Christmas Time!</string>
-    <string name="draft_feature_christmas00_text">Various decorations for Christmas time :)</string>
-    <string name="draft_category_christmas00_title">Winter time</string>
-    <string name="draft_deco_chr_snowman00_title">Snowman</string>
-    <string name="draft_deco_chr_snowman00_text">Children like to build snowmen in winter time.</string>
-    <string name="draft_internationalcommercecentre00_title">ICC</string>
-    <string name="draft_internationalcommercecentre00_text">The International Commerce Centre in Hong Kong is a 108 storey, commercial skyscraper. It\'s the tallest building in Hong Kong with a height of 484 m. It was completed in 2010.</string>
-    <string name="settings_autosave_interval">Autosave interval</string>
-    <string name="settings_autosave_interval_off">Off</string>
-    <string name="settings_autosave_interval_minutes">%1$d min</string>
+    <string name="settings_terrainshading">지형 명암</string>
+    <string name="draft_deco_chr_tree00_title">크리스마스 트리</string>
+    <string name="draft_deco_chr_tree00_text">크리스마스 트리는 시민들의 마음에 기쁨과 영광을 채울 것입니다. 아무 선물이라도 보셨나요?</string>
+    <string name="draft_jardinehouse00_title">자딘 하우스</string>
+    <string name="draft_jardinehouse00_text">자딘 하우스는 홍콩에 위치한 오피스 타워 입니다. 지상 52층에 높이는 179m 입니다. 1972년에 완공 되었습니다. \n(자딘 매터슨은 전신이 영국 동인도 회사이고, 아편전쟁과 깊은연관이있습니다 ㅡ역자, 위키페디아)</string>
+    <string name="draft_bankofchina00_title">중국 은행 타워</string>
+    <string name="draft_bankofchina00_text">중국 은행 타워는 홍콩에 위치한 중국은행 본사입니다. 지상 70층에, 높이는 367m 이고, 1990년에 완공 되었습니다.</string>
+    <string name="settings_road_zone_width">구역 도로 사이 폭</string>
+    <string name="settings_road_zone_height">구역 도로 사이 높이</string>
+    <string name="draft_feature_christmas_pack00_title">크리스마스 스페셜</string>
+    <string name="draft_feature_christmas_pack00_text">한정된 제안으로 다음을 포함합니다:</string>
+    <string name="draft_feature_christmas00_title">크리스마스 연휴!</string>
+    <string name="draft_feature_christmas00_text">크리스마스 연휴를 위한 다양한 장식 :)</string>
+    <string name="draft_category_christmas00_title">겨울</string>
+    <string name="draft_deco_chr_snowman00_title">눈사람</string>
+    <string name="draft_deco_chr_snowman00_text">아이들은 겨울에 눈사람을 만드는 걸 좋아합니다.</string>
+    <string name="draft_internationalcommercecentre00_title">국제 상공 회의소</string>
+    <string name="draft_internationalcommercecentre00_text">홍콩에 위치한 국제 상공 회의소(ICC)는 108층, 상업적 고층 건물 입니다. 높이가 484m 인 홍콩에서 가장 높은 건물 입니다. 2010년에 완공 되었습니다.</string>
+    <string name="settings_autosave_interval">자동 저장 간격</string>
+    <string name="settings_autosave_interval_off">끄기</string>
+    <string name="settings_autosave_interval_minutes">%1$d 분</string>
 
 </resources>


### PR DESCRIPTION
1338 ~ 1350 ㅡ 번역추가
1342 ㅡ 자딘 하우스는 자딘 매터슨의 본사가 위치한 타워입니다. 위의 설명처럼 동인도 회사가 전신은 회사이며, 본래 영국의 수출입 만을 담당하였지만, 영국 의회에 로비를 넣어 **아편전쟁이 9표차이로 일어나게한 회사입니다.**  아편전쟁은 영국역사상 **가장 부당한 전쟁**이라고 알려져 있습니다.

>  (출처 : 자딘 매터슨 ㅡ 위키페디아 , 아편전쟁 ㅡ 비상출판 한국사 中)

번역오류, 어감상 어색한 문장은 피드백 주세요!