### PR TITLE
한글번역 업데이트 / Korean translation update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1339,7 +1339,7 @@
     <string name="draft_deco_chr_tree00_title">크리스마스 트리</string>
     <string name="draft_deco_chr_tree00_text">크리스마스 트리는 시민들의 마음에 기쁨과 영광을 채울 것입니다. 아무 선물이라도 보셨나요?</string>
     <string name="draft_jardinehouse00_title">자딘 하우스</string>
-    <string name="draft_jardinehouse00_text">자딘 하우스는 홍콩에 위치한 오피스 타워 입니다. 지상 52층에 높이는 179m 입니다. 1972년에 완공 되었습니다. \n(자딘 매터슨은 전신이 영국 동인도 회사이고, 아편전쟁과 깊은연관이있습니다 ㅡ역자, 위키페디아)</string>
+    <string name="draft_jardinehouse00_text">자딘 하우스는 홍콩에 위치한 오피스 타워 입니다. 지상 52층에 높이는 179m 입니다. 1972년에 완공 되었습니다.</string>
     <string name="draft_bankofchina00_title">중국 은행 타워</string>
     <string name="draft_bankofchina00_text">중국 은행 타워는 홍콩에 위치한 중국은행 본사입니다. 지상 70층에, 높이는 367m 이고, 1990년에 완공 되었습니다.</string>
     <string name="settings_road_zone_width">구역 도로 사이 폭</string>
@@ -1357,22 +1357,22 @@
     <string name="settings_autosave_interval_off">끄기</string>
     <string name="settings_autosave_interval_minutes">%1$d 분</string>
 
-    <string name="draft_syl_spawner00_title">Torch</string>
-    <string name="draft_syl_spawner00_text">A firework with the shape of a torch.</string>
-    <string name="draft_syl_spawner01_title">Circles</string>
-    <string name="draft_syl_spawner01_text">A rather simple firework.</string>
-    <string name="draft_syl_spawner02_title">Jellyfish</string>
-    <string name="draft_syl_spawner02_text">This firework mimics the shape of a jellyfish.</string>
-    <string name="draft_syl_emitter00_title">Switch</string>
-    <string name="draft_syl_emitter00_text">A switch to initiate fireworks. Connect it to wires.</string>
-    <string name="draft_syl_wire_title">Wire</string>
-    <string name="draft_syl_wire_text">Wiring for fireworks.</string>
-    <string name="draft_category_firework00_title">Fireworks</string>
-    <string name="draft_feature_firework_pack00_title">New Year special</string>
-    <string name="draft_feature_firework_pack00_text">The limited offer contains:</string>
-    <string name="draft_feature_firework00_title">Fireworks</string>
-    <string name="draft_feature_firework00_text">Place and compose your own fireworks.</string>
-    <string name="draft_syl_emitter01_title">Time switch</string>
-    <string name="draft_syl_emitter01_text">A switch that will automatically emit a signal on new year.</string>
+    <string name="draft_syl_spawner00_title">횃불 모양</string>
+    <string name="draft_syl_spawner00_text">횃불 모양 폭죽.</string>
+    <string name="draft_syl_spawner01_title">원 모양</string>
+    <string name="draft_syl_spawner01_text">오히려 단순한 폭죽.</string>
+    <string name="draft_syl_spawner02_title">해파리 모양</string>
+    <string name="draft_syl_spawner02_text">해파리 모양을 따라한 폭죽.</string>
+    <string name="draft_syl_emitter00_title">스위치</string>
+    <string name="draft_syl_emitter00_text">폭죽 놀이를 시작하는 스위치. 로.</string>
+    <string name="draft_syl_wire_title">도화선</string>
+    <string name="draft_syl_wire_text">폭죽과 스위치를 연결합니다.</string>
+    <string name="draft_category_firework00_title">폭죽 놀이</string>
+    <string name="draft_feature_firework_pack00_title">새해 특별판</string>
+    <string name="draft_feature_firework_pack00_text">한정된 제안으로 다음을 포함합니다:</string>
+    <string name="draft_feature_firework00_title">폭죽 놀이</string>
+    <string name="draft_feature_firework00_text">당신만의 폭죽 놀이를 구성하고 설치하세요.</string>
+    <string name="draft_syl_emitter01_title">타임 스위치</string>
+    <string name="draft_syl_emitter01_text">새해에 자동으로 신호를 보내는 스위치 입니다.</string>
 
 </resources>


### PR DESCRIPTION
1360 ~ 1376 ㅡ 번역 추가
1342 ㅡ 충분한 설명이 되었을것이라 생각되어 삭제합니다.
1360, 1362, 1364 ㅡ 너무나 단어가 추상적이라 모양을 추가했습니다.
1363 ㅡ 오히려를 삭제하지 않은 이유는 위아래 문장과 엮어 생각해보면 오히려 단순한 모양이기 때문에 원문을 따랐습니다.
1374 ㅡ compose는 짓다의 의미를 지니고 있습니다. 그러나 place와 호응관계가 좋지 못하여 구성하다로 조금 의미를 확장하여 번역하겠습니다.