### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1462,7 +1462,7 @@
     <string name="settings_saveonappswitch">앱 스위치에 저장</string>
     <string name="settings_saveforscreenshot">스크린샷 저장</string>
     <string name="draft_eiffeltower00_title">에펠탑</string>
-    <string name="draft_eiffeltower00_text">The Eiffel Tower in Paris is the most prominent landmark of France. The tower is 324 metres tall and was finished in 1889.</string>
+    <string name="draft_eiffeltower00_text">에펠탑(Tour Eiffel)은 파리에 위치한 가장 눈에 띄는 프랑스의 렌드마크입니다. 324m 에 1889년 완공된, 만국박람회의 입구로서, 귀스타브 에펠이 설계한 건축물입니다.</string>
     <string name="dialog_wb_text02">당신이 부재중이었던 동안 %1$s 에서 얻은 수익을 가지길 원하신가요?\n\n%2$s</string>
     <string name="dialog_wb_cmdtake">가지기</string>
     <string name="dialog_wb_cmdforfeit">버리기</string>
@@ -1480,9 +1480,11 @@
    a. 한글 번역 업데이트 / Korean translation Update
    b. 한글 맞춤법 수정 / Update about Korean grammar
    c. 오타 수정 / Fix typo
+   d. 부가 번역 / Addition
  ㄴ. 내용
    a. 수정 문장 줄 ㅡ 자세한 수정 내용
    b. 만일 번역에 확신이 들지 않는다면, 해당 사항을 수정 내용에 반드시 명시해주세요.
+   c. 부가 번역에 대해서는 이미 pull request를 한 경우 사용해 주시기바랍니다.
 2. 현재 작업중 내용은 다음과 같습니다.
  ㄱ. 번역물에 대한 한글 맞춤법 검사 (완료 : 1064~1108, 1360~1375, 1433~1459)
  ㄴ. 번역물에 대한 어감 수정 (상시)

--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -624,7 +624,7 @@
     <string name="draft_filterplant00_text">물을 정수합니다.</string>
     <string name="topic_fun">즐갬하세요! :)</string>
     <string name="topic_android">안드로이드 전용</string>
-    <string name="topic_tryharder">더욱 열심히</string>
+    <string name="topic_tryharder">더욱 열심히!</string>
     <string name="topic_nature">자연을 지킵시다</string>
     <string name="topic_time">전 미르가 좋더라구요 아하핳!</string>
     <string name="topic_big">큰것들을 만들어 봅시다!</string>
@@ -692,8 +692,8 @@
     <string name="disaster_riot_cmdtext">그들을 내보내라!</string>
     <string name="draft_beach00_title">해변</string>
     <string name="draft_beach00_text">해변에서의 멋진 하루를 보냅니다.</string>
-    <string name="draft_biergarten00_title">맥주 정원</string>
-    <string name="draft_biergarten00_text">휴식하기에 좋은 곳입니다.</string>
+    <string name="draft_biergarten00_title">비어 가든</string>
+    <string name="draft_biergarten00_text">공용테이블에 맥주와 안주를 제공하는 독일의 야외공간 입니다. 휴식하기에 좋은 곳입니다.</string>
     <string name="notify_noreszone">사람들이 도시에서 살기를 원합니다. 그들을 위해 거주구역을 지정해 주세요.</string>
     <string name="notify_nocomzone">상업 구역을 지정하면 상업 건물이 건설될 것입니다.</string>
     <string name="notify_noindzone">공업 건물이 도시에 지어져야 하지만 먼저 구역을 지정 해야만 합니다.</string>
@@ -854,7 +854,7 @@
     <string name="disaster_ufo_cmdtext">타겟 지정</string>
     <string name="topic_theons">새로운 화폐단위: Theons의 Ͳ</string>
     <string name="topic_wip">내 도시는 내 주관이니 훈수 두지 마세요.</string>
-    <string name="topic_belong">번역 - Yvelkrem / Team nose-cone</string>
+    <string name="topic_belong">번역 - Yvelkrem 과 (Team nose-cone)</string>
     <string name="topic_love">필요한것은 사랑뿐입니다</string>
     <string name="topic_build">나는 길을 찾든지 만들든지 하겠다.</string>
     <string name="topic_news">모두에게 좋은소식!</string>
@@ -864,7 +864,7 @@
     <string name="topic_cats">고양이는 형용할 수 없을 정도로 귀엽다네요.</string>
     <string name="topic_force">포스가 함께하길</string>
     <string name="topic_plugins">이제, 플러그인이 있습니다!</string>
-    <string name="topic_page">www.theotown.com에 방문하세요!</string>
+    <string name="topic_page">www.theotown.com에 방문하세요! 한국 데오타운 디스코드 서버도 방문하세요!</string>
     <string name="topic_habitants">인구수 1,000,000 에 도달할 수 있습니다.</string>
     <string name="ci_statistics_title">통계</string>
     <string name="statistics_inh_all">주민</string>
@@ -1420,7 +1420,7 @@
     <string name="busgame_capacity">수용량</string>
     <string name="busgame_capacity_unit">pl</string>
     <string name="busgame_income">수입</string>
-    <string name="busgame_currency">티켓</string>
+    <string name="busgame_currency">토큰</string>
     <string name="busgame_upgrade">업그레이드</string>
     <string name="busgame_upgrade_title">레벨 %d</string>
     <string name="busgame_unlock">잠금해제</string>
@@ -1459,19 +1459,19 @@
     <string name="dialog_shortbuildtime_text">%s 동안의 고속 건설 부스트를 위해 짧은 광고 보기.</string>
 
 
-    <string name="settings_saveonappswitch">Save on app switch</string>
-    <string name="settings_saveforscreenshot">Save for screenshot</string>
-    <string name="draft_eiffeltower00_title">Eiffel Tower</string>
+    <string name="settings_saveonappswitch">앱 스위치에 저장</string>
+    <string name="settings_saveforscreenshot">스크린샷 저장</string>
+    <string name="draft_eiffeltower00_title">에펠탑</string>
     <string name="draft_eiffeltower00_text">The Eiffel Tower in Paris is the most prominent landmark of France. The tower is 324 metres tall and was finished in 1889.</string>
-    <string name="dialog_wb_text02">Would you like to collect what %1$s earned while you were absent?\n\n%2$s</string>
-    <string name="dialog_wb_cmdtake">Take it</string>
-    <string name="dialog_wb_cmdforfeit">Forfeit</string>
-    <string name="dialog_diamondtool_title">Finish construction</string>
-    <string name="dialog_diamondtool_text">Shall we build that?</string>
-    <string name="draft_feature_valentinesday00_title">Happy Valentine\'s Day</string>
-    <string name="draft_feature_valentinesday00_text">Unlock these buildings permanently</string>
-    <string name="tool_removetunnel_title">Remove tunnel</string>
-    <string name="tool_removetunnel_text">Let\'s remove some tunnels.</string>
+    <string name="dialog_wb_text02">당신이 부재중이었던 동안 %1$s 에서 얻은 수익을 가지길 원하신가요?\n\n%2$s</string>
+    <string name="dialog_wb_cmdtake">가지기</string>
+    <string name="dialog_wb_cmdforfeit">버리기</string>
+    <string name="dialog_diamondtool_title">건설 완료</string>
+    <string name="dialog_diamondtool_text">이것을 바로 건설할까요?</string>
+    <string name="draft_feature_valentinesday00_title">행복회로 발렌타인 데이</string>
+    <string name="draft_feature_valentinesday00_text">영구히 건물 잠금 해제</string>
+    <string name="tool_removetunnel_title">터널 철거</string>
+    <string name="tool_removetunnel_text">터널을 철거해 봅시다.</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
627 ㅡ 느낌표추가
695 ㅡ Biergarten(맥주공원)이라는 독일문화입니다. 고유명사이므로 번역하지 않겠습니다.
696 ㅡ 설명을 추가하였습니다.
867 ㅡ 한국 디스코드 서버 홍보
1423 ㅡ 티켓을 토큰으로 변경. 원문, ticket
1465 ㅡ 에펠탑 설명 번역
1471 ㅡ 비꼬고자 의도한 것입니다. 본래 '행복한'