### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -403,19 +403,19 @@
     <string name="topic_np">P집합과 NP집합이 같을까요?</string>
     <string name="topic_42">42?</string>
     <string name="draft_radio00_news_title">뉴스 104.0</string>
-    <string name="draft_radio00_news_text">도시에 대한 새 이야기를 전합니다. 지식에 영향을 줍니다. 
+    <string name="draft_radio00_news_text">도시에 대한 새로운 이야기를 전합니다. 지식에 영향을 줄겁니다. 
 \n
 \n동시간대에는 하나의 프로그램만 송출될 수 있습니다. 이전 프로그램은 폐지됩니다.</string>
     <string name="draft_radio00_sport_title">스포츠 FM</string>
-    <string name="draft_radio00_sport_text">스포츠 소식과 흥미진진한 경기 생중계를 송출합니다. 먼거리에 스포츠와 같은 효과를 발휘합니다.
+    <string name="draft_radio00_sport_text">스포츠 소식과 흥미진진한 경기 생중계를 송출합니다. 먼거리에 스포츠 효과를 발휘합니다.
 \n
 \n동시간대에는 하나의 프로그램만 송출될 수 있습니다. 이전 프로그램은 폐지됩니다.</string>
     <string name="draft_radio00_fun_title">꿀잼 라디오</string>
-    <string name="draft_radio00_fun_text">대부분 음악과 예능을 송출합니다. 청취자들이 좋아할 것입니다. 따라서 장거리에 공원과 같은 효과를 발휘합니다.
+    <string name="draft_radio00_fun_text">대부분 음악과 예능프로를 송출합니다. 청취자들이 좋아할 것입니다. 장거리에 공원 효과를 발휘합니다.
 \n
 \n동시간대에는 하나의 프로그램만 송출될 수 있습니다. 이전 프로그램은 폐지됩니다.</string>
     <string name="draft_radio00_faith_title">신앙 토크</string>
-    <string name="draft_radio00_faith_text">만물과 우리의 존재에 대한 설교를 송출합니다. 기본적으로 먼거리에 종교와 같은 효과를 발휘합니다.
+    <string name="draft_radio00_faith_text">만물과 우리의 존재에 대한 설교를 송출합니다. 기본적으로 먼거리에 종교 효과를 발휘합니다.
 \n
 \n동시간대에는 하나의 프로그램만 송출될 수 있습니다. 이전 프로그램은 폐지됩니다.</string>
     <string name="draft_lighthouse00_title">등대</string>
@@ -458,7 +458,7 @@
     <string name="tutorial_speed_fast">대기시간을 줄이기 위해서 시물레이션 속도를 변경할 수도 있습니다.</string>
     <string name="tutorial_speed_normal">이제 다시 원래의 속도로 맞추세요.</string>
     <string name="tutorial_money_task">당신의 임무는 이 도시를 세금으로 얻은 돈으로서 발선시켜 나가는 것입니다.</string>
-    <string name="tutorial_money_info">우측하단의 버튼을 눌러서 재정과 세율에 대한 자세한 정보를 확인할 수 있습니다.</string>
+    <string name="tutorial_money_info">우측 하단의 버튼을 눌러서 재정과 세율에 대한 자세한 정보를 확인할 수 있습니다.</string>
     <string name="tutorial_congrats">축하합니다! Theotown의 기본을 모두 배웠습니다. 이젠 당신만의 도시를 시작할 수 있습니다. :)</string>
     <string name="draft_road03_title">일방 통행 도로</string>
     <string name="draft_road03_text">오직 한 방향으로만 통행이 가능한 도로입니다. 교통 체증을 조절하기 위해 사용됩니다.</string>
@@ -473,22 +473,22 @@
     <string name="settings_disaster_illness">전염병</string>
     <string name="settings_disaster_flooding">홍수</string>
     <string name="settings_disaster_godzilla">고질라</string>
-    <string name="settings_disaster_auto">재난 자동화</string>
+    <string name="settings_disaster_auto">재난 자연 발생</string>
     <string name="notify_firenodp">화재가 발생했습니다! 화제진압을 위해 소방서를 건설하세요.</string>
     <string name="draft_destroyedtile_title">구조물 잔해</string>
-    <string name="draft_destroyedtile_text">구조물 잔해입니다. 반드시 이것은 철거해야만 합니다.</string>
+    <string name="draft_destroyedtile_text">구조물 잔해입니다. 이것은 반드시 철거해야만 합니다.</string>
     <string name="disaster_fire_title">화재</string>
     <string name="disaster_fire_text">다 태워버려!</string>
     <string name="disaster_fire_cmdtext">불타오르라!</string>
     <string name="disaster_meteorite_title">운석 충돌</string>
-    <string name="disaster_meteorite_text">하늘에서 운석우가 내리도록 합시다!</string>
-    <string name="disaster_meteorite_cmdtext">날아오르라!</string>
+    <string name="disaster_meteorite_text">하늘에서 운석우가 빗발치도록 합시다!</string>
+    <string name="disaster_meteorite_cmdtext">내려오리라!</string>
     <string name="disaster_earthquake_title">지진</string>
-    <string name="disaster_earthquake_text">온 땅이 흔들리도록 합시다!</string>
+    <string name="disaster_earthquake_text">온 대지가 흔들리도록 합시다!</string>
     <string name="disaster_earthquake_cmdtext">흔들리거라!</string>
     <string name="disaster_illness_title">전염병</string>
-    <string name="disaster_illness_text">사람들이 병에 걸릴겁니다...</string>
-    <string name="disaster_illness_cmdtext">널리퍼저라!</string>
+    <string name="disaster_illness_text">수많은 사람들이 질병에 걸릴겁니다...</string>
+    <string name="disaster_illness_cmdtext">감염이 시작되었다!</string>
     <string name="disaster_flooding_title">홍수</string>
     <string name="disaster_flooding_text">너무 물이 많습니다.</string>
     <string name="disaster_flooding_cmdtext">폭우여 내려라!</string>
@@ -496,7 +496,7 @@
     <string name="ci_loan_title">대출</string>
     <string name="ci_loan_donate">구걸</string>
     <string name="ci_loan_get">대출금 증액</string>
-    <string name="ci_loan_donate_text">부탁합니다. 잔돈이라도 주십시오. 전 정말로 필요합니다. :(</string>
+    <string name="ci_loan_donate_text">부탁합니다. 잔돈이라도 주십시오. 정말로 전 한푼이라도 필요합니다. :(</string>
     <string name="ci_loan_get_text">일반 대출, 10,000Ͳ
 \n대출금 상환 기간: 24 개월
 \n월간 이자: 500Ͳ</string>
@@ -506,19 +506,19 @@
     <string name="draft_crater1x1_text">작은 운석 구덩이. 반드서 철거해야 합니다.</string>
     <string name="settings_disaster_nuke">핵폭탄</string>
     <string name="disaster_nuke_title">핵폭발</string>
-    <string name="disaster_nuke_text">무해한듯 합니다.</string>
+    <string name="disaster_nuke_text">대채로 무해한듯 보이네요.</string>
     <string name="disaster_nuke_cmdtext">시도해보기</string>
     <string name="budget_loans">대출</string>
     <string name="ci_loan_loanlist">활성화된 대출 (%3$,d개중 %2$,d 대출중, 총 %1$s):</string>
     <string name="ci_loan_remaining_runtime">대출금 상환 기간: %2$,d 개월, %1$,d 일 남음. </string>
     <string name="ci_loan_paybackcost">대출 상환금: %1$s</string>
     <string name="ci_loan_estate">재정: %1$s</string>
-    <string name="topic_support_ads">광고를 누르는 것으로 우리를 도울 수도 있습니다. :)</string>
+    <string name="topic_support_ads">광고를 누르는 것만으로 저희를 도울 수 있습니다. :)</string>
     <string name="settings_disaster_tornado">토네이도</string>
     <string name="disaster_tornado_title">토네이도</string>
-    <string name="disaster_tornado_text">토네이도는 도시의 굉장한 위험 입니다.</string>
+    <string name="disaster_tornado_text">토네이도는 도시의 가장 큰 위험입니다.</string>
     <string name="disaster_tornado_cmdtext">토네이도 설치하기</string>
-    <string name="buildinginfo_untouchable">재건축불가</string>
+    <string name="buildinginfo_untouchable">재건축 금지</string>
     <string name="draft_zoneresidential_lvl2_title">밀집 주거 구역</string>
     <string name="draft_zoneresidential_lvl2_text">높은 밀도의 주거 구역입니다.</string>
     <string name="draft_zonecommercial_lvl2_title">밀집 상업 구역</string>
@@ -526,21 +526,21 @@
     <string name="draft_zoneindustrial_lvl2_title">밀집 산업 구역</string>
     <string name="draft_zoneindustrial_lvl2_text">높은 밀도의 산업 구역입니다.</string>
     <string name="draft_zonefarm_title">농장</string>
-    <string name="draft_zonefarm_text">농장건물을 위한 값싼 구역입니다. 농장을 위한 최소크기는 4x4입니다.</string>
-    <string name="requirement_peoplecount_all">필요:%1$,d 명의 인구.</string>
-    <string name="requirement_peoplecount_poor">필요: A %1$,d명의 저소득층 인구.</string>
-    <string name="requirement_peoplecount_middle">필요: %1$,d명의 중산층 인구.</string>
-    <string name="requirement_peoplecount_rich">필요: %1$,d명의 고소득층 인구.</string>
+    <string name="draft_zonefarm_text">농장을 위한 저렴한 구역입니다. 농장을 건설하기 위한 최소크기는 4x4입니다.</string>
+    <string name="requirement_peoplecount_all">%1$,d 명의 인구 필요.</string>
+    <string name="requirement_peoplecount_poor">%1$,d명의 저소득층 인구 필요.</string>
+    <string name="requirement_peoplecount_middle">%1$,d명의 중산층 인구 필요.</string>
+    <string name="requirement_peoplecount_rich">%1$,d명의 고소득층 인구 필요.</string>
     <string name="requirement_building">필요: %1$s</string>
     <string name="draftselector_onlyone">한번만 건설할 수 있습니다.</string>
     <string name="draftselector_onlyn">%1$,d번 건설할 수 있습니다.</string>
     <string name="draft_church02_title">작은 교회</string>
-    <string name="draft_church02_text">마을을 위한 작은 교회입니다.</string>
+    <string name="draft_church02_text">작은 마을을 위한 작은 교회입니다.</string>
     <string name="draft_mosque01_title">작은 모스크</string>
-    <string name="draft_mosque01_text">작은 모스크입니다.</string>
+    <string name="draft_mosque01_text">작은 마을을 위한 작은 모스크입니다.</string>
     <string name="settings_sound_ui">UI 소리</string>
     <string name="settings_sound_game">게임 소리</string>
-    <string name="settings_preserveedges">영역경계 유지</string>
+    <string name="settings_preserveedges">영역 경계선 유지</string>
     <string name="settings_fancybg">화려한 배경</string>
     <string name="ci_not_available">표시할 정보가 없음.</string>
     <string name="ci_education_title">교육</string>
@@ -567,15 +567,15 @@
     <string name="influence_religion_title">종교</string>
     <string name="influence_culture_title">문화</string>
     <string name="influence_culture_text">도시의 문화 수준입니다.</string>
-    <string name="influence_education_low_text">학교는 낮은 수준의 교육을 제공합니다.</string>
-    <string name="influence_education_high_text">고등학교에서 높은 수준의 교육이 제공됩니다.</string>
-    <string name="influence_firedep_text">소방서의 영향은 화재 발생 가능성을 낮춰줍니다.</string>
-    <string name="influence_health_text">의사들은 시민들을 건강하게 유지시켜 줍니다.</string>
+    <string name="influence_education_low_text">초등학교와 중학교는 비교적 낮은 단계의 교육을 제공합니다.</string>
+    <string name="influence_education_high_text">고등학교는 비교적 높은 단계의 교육을 제공합니다.</string>
+    <string name="influence_firedep_text">소방서는 화재 발생 가능성을 낮춰주는데 영향을 미칩니다.</string>
+    <string name="influence_health_text">의사는 시민을 건강을 유지할 수 있도록 도와줍니다.</string>
     <string name="influence_noise_text">소음이 심한 지역에서는 아무도 살고싶지 않을 겁니다.</string>
     <string name="influence_park_text">시민를 행복하게 하고 건물 밀집도를 높일 수 있습니다.</string>
-    <string name="influence_police_text">범죄 행위를 견제하십시오.</string>
+    <string name="influence_police_text">범죄가 일어나지 않도록 하십시오.</string>
     <string name="influence_pollution_text">오염이 심한 지역에서는 아무도 살고싶지 않을 겁니다.</string>
-    <string name="influence_religion_text">종교는 시민들의 특성을 증가시킵니다.</string>
+    <string name="influence_religion_text">종교는 시민들의 행복도를 증가시킵니다.</string>
     <string name="influence_sport_text">시민들의 건강을 책임집니다.</string>
     <string name="draftselector_cmdShow">보이기</string>
     <string name="ca_education_low_text">초,중등 교육: %2$,d명중 %1$,d명의 학생</string>
@@ -586,7 +586,7 @@
     <string name="draft_zoneharbor_text">도시의 해안가를 위한 산업 구역입니다</string>
     <string name="settings_auto_road_for_zones">구역지정 도구에서 도로 건설.</string>
     <string name="settings_relaxed_line_tool">간단한 직선도구</string>
-    <string name="topic_fstapril">4월 1일 축하! 오예</string>
+    <string name="topic_fstapril">오늘은 만우절이 아닙니다.</string>
     <string name="draftselector_residential">주거</string>
     <string name="draftselector_commercial">상업</string>
     <string name="draftselector_industrial">공업</string>
@@ -605,15 +605,15 @@
     <string name="draft_marker_protectedmarker_title">보호된 건물</string>
     <string name="draft_marker_protectedmarker_text">철거가 불가능한 건물 보이기.</string>
     <string name="draft_marker_trafficmarker_title">교통</string>
-    <string name="draft_marker_trafficmarker_text">교통</string>
-    <string name="draft_mayorvilla00_title">별장</string>
-    <string name="draft_mayorvilla00_text">시장을 위한 꽤나 좋은 집입니다.</string>
+    <string name="draft_marker_trafficmarker_text">도로의 정체, 연결여부 등을 확인합니다.</string>
+    <string name="draft_mayorvilla00_title">시장 관저</string>
+    <string name="draft_mayorvilla00_text">시장을 위한 상당히 좋은 집입니다.</string>
     <string name="happiness_health">보건</string>
     <string name="happiness_firedanger">화재 위험</string>
     <string name="dialog_screenshot_show">보기</string>
     <string name="draft_townhall01_title">시청</string>
     <string name="draft_townhall01_text">이 도시에 어울릴 건물입니다.</string>
-    <string name="loadcity_errordialog_cmdrecover">회복</string>
+    <string name="loadcity_errordialog_cmdrecover">복구</string>
     <string name="draft_plaza00_title">마을 광장</string>
     <string name="draft_plaza00_text">마을 회관을 위한 마을광장</string>
     <string name="topic_birthday_theotown">생일 축하합니다! TheoTown :D</string>
@@ -624,23 +624,23 @@
     <string name="draft_filterplant00_text">물을 정수합니다.</string>
     <string name="topic_fun">즐갬하세요! :)</string>
     <string name="topic_android">안드로이드 전용</string>
-    <string name="topic_tryharder">더욱 열심히!</string>
+    <string name="topic_tryharder">더욱 열심히 합시다!</string>
     <string name="topic_nature">자연을 지킵시다</string>
-    <string name="topic_time">전 미르가 좋더라구요 아하핳!</string>
-    <string name="topic_big">큰것들을 만들어 봅시다!</string>
+    <string name="topic_time">전 미르가 좋더라구요. 크앙! ㅡ역자</string>
+    <string name="topic_big">더 크게 만들어 보세요!</string>
     <string name="buildinginfo_waterwaste">하수: %1$.1f%%</string>
-    <string name="ci_water_waste">사용된: %1$.1f%%</string>
-    <string name="shader_fancy2">초ㅡ화려</string>
+    <string name="ci_water_waste">: %1$.1f%%</string>
+    <string name="shader_fancy2">더욱 화려하게</string>
     <string name="draft_sewerpipe00_title">폐수관</string>
-    <string name="draft_sewerpipe00_text">폐수를 자연으로 방출합니다. 나쁜 영향을 끼칩니다.</string>
+    <string name="draft_sewerpipe00_text">폐수를 자연으로 방출해 하수를 줄입니다. 나쁜 영향을 끼칩니다.</string>
     <string name="settings_lowresmapscreenshot">저해상도 맵 스크린샷</string>
     <string name="draft_marina00_title">선착장</string>
-    <string name="draft_marina00_text">부자들이 이곳에서 여가생활을 즐깁니다.</string>
+    <string name="draft_marina00_text">여기에서 부자들은 여가생활을 즐깁니다.</string>
     <string name="loadcity_version">버전 %1$,d</string>
     <string name="loadcity_memdialog_title">외부 저장공간에 대해 접근 권한 없음</string>
     <string name="loadcity_memdialog_text">도시들은 내부 저장공간에 저장될 것입니다. 권한을 부여할 필요는 없을 것입니다.</string>
-    <string name="loadcity_memdialog_cmdremind">기억해주세요</string>
-    <string name="loadcity_memdialog_cmdok">신경 마세요.</string>
+    <string name="loadcity_memdialog_cmdremind">나중에 다시 알려주세요.</string>
+    <string name="loadcity_memdialog_cmdok">알겠습니다.</string>
     <string name="about_translation">번역</string>
     <string name="draft_decocom00_title">상업 구역</string>
     <string name="draft_decores00_title">주거 구역</string>
@@ -648,15 +648,15 @@
     <string name="settings_shaderconfig">색상</string>
     <string name="settings_shadertype_normal">보통</string>
     <string name="settings_shadertype_fancy">화려</string>
-    <string name="settings_shadertype_xfancy">초ㅡ화려</string>
+    <string name="settings_shadertype_xfancy">더욱 화려하게</string>
     <string name="draft_buoy00_title">부표</string>
-    <string name="draft_buoy00_text">선박이 길을 찾기 위해 필요합니다.</string>
+    <string name="draft_buoy00_text">선박이 길을 찾기 위해서 반드시 필요합니다.</string>
     <string name="ci_general_seed">시드: %1$s</string>
     <string name="draft_decores00_text">주거 구역 장식</string>
     <string name="draft_decocom00_text">상업 구역 장식</string>
     <string name="draft_decoind00_text">산업 구역 장식</string>
     <string name="ci_budget_title_nomoney">금융</string>
-    <string name="dialog_notification_cmdok">오케이</string>
+    <string name="dialog_notification_cmdok">네</string>
     <string name="draft_nuclearplant00_title">원자력 발전소</string>
     <string name="draft_nuclearplant00_text">석탄 발전소 보다 강력합니다. 유지비가 많이들고. 냉각을위해 매우 많은 물이 필요합니다. 물이 없다면 폭발할지도 모릅니다.</string>
     <string name="draft_gasplant00_title">가스 발전소</string>
@@ -854,7 +854,7 @@
     <string name="disaster_ufo_cmdtext">타겟 지정</string>
     <string name="topic_theons">새로운 화폐단위: Theons의 Ͳ</string>
     <string name="topic_wip">내 도시는 내 주관이니 훈수 두지 마세요.</string>
-    <string name="topic_belong">번역 - Yvelkrem 과 (Team nose-cone)</string>
+    <string name="topic_belong">번역 ㅡ Yvelkrem , 검수 ㅡ LegenDUST</string>
     <string name="topic_love">필요한것은 사랑뿐입니다</string>
     <string name="topic_build">나는 길을 찾든지 만들든지 하겠다.</string>
     <string name="topic_news">모두에게 좋은소식!</string>
@@ -1579,28 +1579,28 @@
     <string name="draft_underground_wire00_title">전선 지중화</string>
     <string name="draft_underground_wire00_text">일반 전선과 기능이 같습니다, 하지만 땅속에 건설되기 때문에 누구도 전선을 볼 수 없을 것입니다.</string>
     <string name="draft_feature_freedombuildings00_title">랜드마크 1번 팩</string>
-    <string name="draft_feature_freedombuildings00_text">영구 사용으로써 다음건물을 포함합니다.:</string>
+    <string name="draft_feature_freedombuildings00_text">영구적으로 사용할 수 있는 다음 건물을 포함합니다.:</string>
 
 
     <string name="tool_removeuwire_title">전선 지중화</string>
     <string name="tool_removeuwire_text">이 도구는 지중화된 전선을 철거합니다.</string>
 
 
-    <string name="draft_aircraft_boneyard00_title">Aircraft boneyard</string>
-    <string name="draft_aircraft_boneyard00_text">A place for retired aircraft. It\'s dirty but produces some income.</string>
-    <string name="notify_tutorial_reminder_title">Time to get started</string>
-    <string name="notify_tutorial_reminder_text">Hey mayor, did you forget about your mission to build a great city?</string>
-    <string name="dialog_insufficientspace_title">We\'re running out of space</string>
-    <string name="dialog_insufficientspace_text">There\'s not much free space left on your device (%,d MB).\n\nCities might not be saved due to insufficient space!</string>
-    <string name="dialog_insufficientspace_cmdproceed">Proceed at own risk</string>
-    <string name="draft_sydneyoperahouse00_title">Sydney Opera House</string>
-    <string name="draft_sydneyoperahouse00_text">The Sydney Opera House is a multi-venue performing arts centre that is located in Sydney, Australia. It was completed in 1973 and has a height of 65 meters.</string>
-    <string name="draft_onerafflesplace00_title">One Raffles Place</string>
-    <string name="draft_onerafflesplace00_text">The One Raffles Place is a skyscraper in the city of Singapore that was built in 1986 and has a height of 280 meters.</string>
-    <string name="draft_willistower00_title">Willis Tower</string>
-    <string name="draft_willistower00_text">The Willis Tower (also known as Sears Tower) is a skyscraper that is located in Chicago, United States. The tower was built in 1973 and is 442 meters high.</string>
-    <string name="draft_feature_landmarks01_title">Landmarks II</string>
-    <string name="draft_feature_landmarks01_text">Contains the following buildings for permanent usage:</string>
+    <string name="draft_aircraft_boneyard00_title">비행기 묘지</string>
+    <string name="draft_aircraft_boneyard00_text">은퇴한 비행기들을 위한 장소입니다. 더러운 장소이지만 약간의 수입을 얻습니다.</string>
+    <string name="notify_tutorial_reminder_title">시작하기</string>
+    <string name="notify_tutorial_reminder_text">거기 시장님, 대도시를 만들기 위한 시장님의 임무를 잊어버리신 건가요?</string>
+    <string name="dialog_insufficientspace_title">공간이 부족합니다.</string>
+    <string name="dialog_insufficientspace_text">기기에 남은 공간이 얼마 없습니다 (%,d MB).\n\n부족한 공간 때문에 도시가 저장되지 않을 수도 있습니다!</string>
+    <string name="dialog_insufficientspace_cmdproceed">위험 감수하기</string>
+    <string name="draft_sydneyoperahouse00_title">시드니 오페라 하우스</string>
+    <string name="draft_sydneyoperahouse00_text">시드니 오페라 하우스(Sydney Opera House)는 오스트레일리아 시드니에 위치한 1973년 완공된 복합공연센터 입니다. 건축가 이외른 우촌이 오랜지 껍질을 벋기다 생각한 디자인이라고 합니다.</string>
+    <string name="draft_onerafflesplace00_title">OUB 센터</string>
+    <string name="draft_onerafflesplace00_text">원 래플스 플레이스(One Raffles Place)는 싱가포르 다운타운 코어에 위치한 마천루 단지입니다. 1987년 완공당시 63타워를 제치고 1990년가지 지상63층, 280미터로 아시아최고층 건물 이었습니다.</string>
+    <string name="draft_willistower00_title">윌리스 타워</string>
+    <string name="draft_willistower00_text">윌리스 타워(Willis Tower)는 1973년 완공된 미국 시카고 일리노이에 지어진 마천루입니다. 2013년까지 지상 108층, 442미터로 서반구 최대높이 건물이었습니다. 9개의 튜브로 이루어진 묶음튜브구조 입니다.</string>
+    <string name="draft_feature_landmarks01_title">랜드마크 2번 팩</string>
+    <string name="draft_feature_landmarks01_text">영구적으로 사용할 수 있는 다음 건물을 포함합니다.:</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
406 ㅡ 어감 수정
414 ㅡ 어감 수정
417 ㅡ "과 같은" 제거
461 ㅡ 띄어쓰기 반영
476 ㅡ 재난 자동화를 재난 자연 발생으로 수정
479 ㅡ 잘못된 어순 수정
484,5 ㅡ 더 나은 번역 반영
487 ㅡ 땅을 대지로 수정
490 ㅡ 어감 수정
491 ㅡ 어감 수정
499 ㅡ 더나은 번역 반영
509 ㅡ 더나은 번역 반영
516 ㅡ 어감 수정
519 ㅡ 어감 수정
512 ㅡ 띄어쓰기, 어감 수정
529 ㅡ 어감 수정
530,1,2,3 ㅡ 어순 수정
538,40 ㅡ 작은 추가로 어감 수정
543 ㅡ 영역 경계선 유지로 변경
570,1 ㅡ 수준을 교육의 질로 착각가능하여 단계로 변경
572 ㅡ 소방서 설명 변경
573 ㅡ 불필요한 복수형과 이상한 어감 수정
576 ㅡ 더나은 번역 반영
578 ㅡ 원문이 그렇다면 바꿔여죠.
589 ㅡ 더나은 문장 반역
608 ㅡ 한단어가 전부였던 원문을 버리고 새로 작성
609,10 ㅡ 어감 수정
616 ㅡ 오역 수정
627 ㅡ 어감 수정
629 ㅡ 유행지난 유행어는 없에는것이 맞죠. 동의합니다.
630 ㅡ 명령문으로 복구
632 ㅡ 적용되지 않은 하수 수정
633 ㅡ 더나은 번역 반영
635 ㅡ 원문엔 있지만 번역문엔 없는 내용 추가
638 ㅡ 어순 수정
642,3 ㅡ 오역 수정
653 ㅡ 어감 수정
857 ㅡ 상당히 많은 피드백을 주셨으니 이정도는 해야죠. 암.
1589~1603 ㅡ 새로 추가된 부분 번역