### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1675,12 +1675,11 @@
     <string name="draft_asphalt01_title">어두운 아스팔트</string>
     <string name="draft_asphalt02_title">푸르스름한 아스팔트</string>
 
-
-    <string name="draft_cat_management00_title">Management</string>
-    <string name="draft_sakura00_title">Sakura tower</string>
-    <string name="draft_sakura00_text">A traditional pagoda with Sakura trees. What a lovely place.</string>
-    <string name="draft_stbasilcathedral00_title">St Basil\'s Cathedral</string>
-    <string name="draft_stbasilcathedral00_text">The Saint Basil\'s Cathedral is a church in Moscow, Russia. It was completed in 1561 and is now a museum. Its height amounts to 115 meters.</string>
+    <string name="draft_cat_management00_title">행정</string>
+    <string name="draft_sakura00_title">도지 5중탑</string>
+    <string name="draft_sakura00_text">도지(東寺)의 본명인 교오고코쿠지(教王護国寺)는 교토 미나미구에 위치한 불교 사찰입니다. 이곳에 위치한 5중탑(五重塔)은 55m로 일본에서 가장 높은 목조 건축물이면서 일본의 국보 건조물 제86호입니다. 826년에 지어졌으나 4차례나 소실된적이 있습니다.</string>
+    <string name="draft_stbasilcathedral00_title">성 바실리 대성당</string>
+    <string name="draft_stbasilcathedral00_text">성 바실리 대성당(Храм Василия Блаженого)은 러시아 모스크바의 붉은 광장 남쪽에 위치한 9개의 독특한 양파형 지붕이 특징인 성당입니다. 1560년에 115m로 완공되었고, 테트리스의 배경으로도 유명합니다.</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
Sakura tower's original name is _Toji - 5 floor pagoda._ --> https://en.wikipedia.org/wiki/T%C5%8D-ji
Also, this is a most famous pagoda in gyoto, japan.

It will better to in landmark category

1679 ㅡ 본래 건물은 5층목탑입니다. 그러나 여기선 고증오류로 4층으로 만들어져있습니다. 첨탑 고유의 디자인으로 미루어보아 교토의 랜드마크인 5중탑이 맞습니다.