### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1716,25 +1716,23 @@
     <string name="draft_flowers00_title">꽃밭</string>
     <string name="draft_flowers00_text">그저 평범한 꽃들.</string>
 
+    <string name="game_remaining_doubledincometime">%s 동안 수익 2배</string>
+    <string name="draft_taipei101_title">타이페이 101</string>
+    <string name="draft_taipei101_text">타이베이금융센터(臺北金融大樓)는 대만 타이베이시 남동부에 위치한 거대 마천루 입니다. 2004년 개장부터 2010년까지 지상 101층, 509.2m로 세계 최고층 마천루 였습니다. 바로 이곳에 유명한 6t의 지진 대비용 금색 대형 진자가 있습니다.</string>
+    <string name="draft_roaddeco_border00_title">델리네이터</string>
+    <string name="draft_roaddeco_border00_text">차량들이 도로를 잃어버리지 않도록 도와줍니다.</string>
+    <string name="draft_roaddeco_border01_title">가변 돌</string>
+    <string name="draft_roaddeco_border01_text">도로 옆에 누워있는 단순히 장식적인 돌.</string>
+    <string name="draft_roaddeco_border02_title">가드레일</string>
+    <string name="draft_roaddeco_border02_text">안전제일.</string>
+    <string name="draft_roaddeco_border03_title">방음벽</string>
+    <string name="draft_roaddeco_border03_text">무슨 소음이요? 전 아무것도 않들립니다.</string>
+    <string name="draft_roaddeco_border04_title">투명 방음벽</string>
+    <string name="draft_roaddeco_border04_text">차량이 지나다니는것을 볼 수 있습니다.</string>
+    <string name="draft_roaddeco_border05_title">가로등</string>
+    <string name="draft_roaddeco_border05_text">밤이 없지만 가로등이 있습니다.</string>
 
-    <string name="game_remaining_doubledincometime">Doubled income for %s</string>
-    <string name="draft_taipei101_title">Taipei 101</string>
-    <string name="draft_taipei101_text">The Taipei Financial Center in Taipei is a supertall skyscraper in Taiwan. It has a height of 510 meters and has been the tallest building in the world until 2010. It was finished in 2004.</string>
-    <string name="draft_roaddeco_border00_title">Guide post</string>
-    <string name="draft_roaddeco_border00_text">Helps cars to keep track.</string>
-    <string name="draft_roaddeco_border01_title">Stone border</string>
-    <string name="draft_roaddeco_border01_text">Just some decorative stones lying near your road.</string>
-    <string name="draft_roaddeco_border02_title">Guard railing</string>
-    <string name="draft_roaddeco_border02_text">Safety first.</string>
-    <string name="draft_roaddeco_border03_title">Sound protection</string>
-    <string name="draft_roaddeco_border03_text">Which noise? I don\'t hear any.</string>
-    <string name="draft_roaddeco_border04_title">Glass wall</string>
-    <string name="draft_roaddeco_border04_text">You can see cars through it.</string>
-    <string name="draft_roaddeco_border05_title">Street lighting</string>
-    <string name="draft_roaddeco_border05_text">There\'s no night and yet there are street lights.</string>
-
-
-    <string name="draft_cat_roaddeco00_title">Road decoration</string>
+    <string name="draft_cat_roaddeco00_title">도로 장식</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
1722 ㅡ 델리네이터는 도로가 눈등으로 덮여서 보이지 않을경우 이곳에 도로가있다는 것을 알려주기 위해 가변에 밖아놓는 표지입니다. 한국에서는 중앙분리대에 보이는 동그란 반사판이 바로 그것입니다.
1726 ~ 32 ㅡ 본래는 ~하기(~ing)형태이나 한국어로 적절하지 않다고 생각되어 수정하였습니다.