### PR TITLE
Update zh-cn translations

### DIFF
--- a/values-zh/strings.xml
+++ b/values-zh/strings.xml
@@ -1805,13 +1805,13 @@
     <string name="feature_coming_soon_fulfilled">早期的礼物</string>
 
 
-    <string name="draft_tree_sakura00_title">樱花盛开</string>
-    <string name="draft_tree_sakura00_text">它们表面上是樱花树，但是它们不会张出樱桃来。</string>
+    <string name="draft_tree_sakura00_title">樱花树</string>
+    <string name="draft_tree_sakura00_text">它们表面上是樱花树，但是它们不会长出樱桃来。</string>
     <string name="draft_circus00_title">马戏团</string>
-    <string name="draft_circus00_text">马戏团的时间到了</string>
+    <string name="draft_circus00_text">是时候来点马戏了</string>
     <string name="draft_chrysler00_title">克莱斯勒大厦</string>
-    <string name="draft_chrysler00_text">你可能曾经看过这个建筑物。 位于纽约的克莱斯勒大厦的著名是它的标志性的外观并在1930年竣工，它的高度为319米。</string>
-    <string name="draft_greatpyramid00_text">吉萨金字塔群是古代世界七大奇迹的其中之一并被大众广为人知其中又以胡夫金字塔闻名。同时它是在吉萨金字塔最高的并且它的高度为139米。</string>
-    <string name="draft_feature_landmarks04_text">拥有最好的建筑群。</string>
+    <string name="draft_chrysler00_text">你之前可能看过这座大楼。位于纽约的克莱斯勒大厦因其标志性外观而闻名。建于1930年，建筑高319米。</string>
+    <string name="draft_greatpyramid00_text">吉萨金字塔建筑群是古代世界七大奇迹中最古老的，也是举世闻名的。大金字塔是三座金字塔中最大的一座，高139米。</string>
+    <string name="draft_feature_landmarks04_text">来点宏大的建筑！</string>
 
 </resources>


### PR DESCRIPTION
I have found something weird about this repo.
When I clone this repo in github destop and other git client, it seems that its size is nearly 1.2GB.
But the translating part is less than 5MB and the apk is less than 50 MB.
Haven't seen this issue on other repos.
Here's what it look like:
、
![default](https://user-images.githubusercontent.com/30719670/41184206-5cfb639c-6bb1-11e8-8586-50ca9bf79c90.png)
Have a nice day!