### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1792,11 +1792,10 @@
     <string name="draft_medic02_text">작은 병원은 더 많은 환자들을 위한 더 많은 공간을 제공합니다.</string>
     <string name="lang_pirate">해적(pirate)</string>
 
-
-    <string name="draft_church10_title">Baroque Church</string>
-    <string name="draft_church10_text">A beautiful church and convent for your city.</string>
-    <string name="draft_roaddeco_construction00_title">Bagger</string>
-    <string name="draft_roaddeco_construction00_text">A bagger in the middle of the road doesn\'t sound like a good idea, does it?</string>
+    <string name="draft_church10_title">바로크 성당</string>
+    <string name="draft_church10_text">도시를 위한 아름다운 성당.</string>
+    <string name="draft_roaddeco_construction00_title">굴착기</string>
+    <string name="draft_roaddeco_construction00_text">도로 한가운데의 굴착기는 그다지 좋은 아이디어 같지는 않네요. 그렇지 않은가요?</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
1796 ㅡ 원문의 convent(수도원)은 어감상 매우 부적절하여 뺐습니다. 원번역은 "당신의 도시를 위한 아름다운 성당과 수도원"입니다.