### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1797,20 +1797,18 @@
     <string name="draft_roaddeco_construction00_title">굴착기</string>
     <string name="draft_roaddeco_construction00_text">도로 한가운데의 굴착기는 그다지 좋은 아이디어 같지는 않네요. 그렇지 않은가요?</string>
 
+    <string name="infoline_freetunnels">터널 %d 칸 남음</string>
+    <string name="buildinginfo_idletime">유휴 시간 : %s (당신이 도시에 있었는지 없었는지)</string>
+    <string name="dialog_wb_completed">축하드립니다! 마지막으로 방문했을 때로부터 %d 채의 건물이 완공되었습니다.</string>
+    <string name="draft_roaddeco_barrier01_title">바리케이드</string>
+    <string name="draft_roaddeco_barrier01_text">도로를 막기 위해 사용될 수 있습니다.</string>
+    <string name="draft_roaddeco_construction01_title">자갈 언덕</string>
+    <string name="draft_roaddeco_construction01_text">좋은 도로공사의 일부분.</string>
 
-    <string name="infoline_freetunnels">%d tunnels left</string>
-    <string name="buildinginfo_idletime">Idle time: %s (if you are not in the city)</string>
-    <string name="dialog_wb_completed">Congratulations, %d buildings have been completed since your last visit.</string>
-    <string name="draft_roaddeco_barrier01_title">Barricades</string>
-    <string name="draft_roaddeco_barrier01_text">Can be used to barricade the road.</string>
-    <string name="draft_roaddeco_construction01_title">Gravel mountains</string>
-    <string name="draft_roaddeco_construction01_text">Part of good roadworks.</string>
-
-
-    <string name="notification00_sandbox_title">NEWS: %1$s is a nice city!</string>
-    <string name="notification00_sandbox_text">Mayor, you can be proud of yourself!</string>
-    <string name="notification01_title">NEWS: %1$s feels lonely!</string>
-    <string name="notification01_text">Mayor, please come back!</string>
+    <string name="notification00_sandbox_title">속보: %1$s, 이곳은 멋진 도시입니다!</string>
+    <string name="notification00_sandbox_text">시장님, 시장님 자신을 자랑스러워 할 수 있습니다!</string>
+    <string name="notification01_title">속보: %1$s에서 외로움을 느낍니다!</string>
+    <string name="notification01_text">시장님, 제발 돌아오세요!</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
1800 ㅡ 조수사를 알수가 없습니다. 우선 "칸"으로 번역합니다.
1808 ㅡ 은/는 사용을 피하기 위해 도시이름을 이곳으로 따로 지칭하여 연결하였습니다.