### PR TITLE
한글 맞춤법 수정 / Update about Korean grammar

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -999,8 +999,8 @@
     <string name="draft_mltry_tankbase00_text">군용 중장비를 위한 병참부입니다.</string>
     <string name="draft_mltry_rocketlauncher00_text">UFO격추를 위해 사용가능 합니다. 민간 차량이나 건물을 향해서는 발사되지 않을것 입니다.</string>
     <string name="draft_mltry_missilesilo00_text">정부는 이 도시에서 로켓실험을 하는것을 원할겁니다. 이 실험 때문에 재해가 닥친다면, 피해에 대한 보상을 받을 것입니다.</string>
-    <string name="draft_decosmallmountain00_text">이 작은 산은 관광객들에게 이 거이 평평한 땅의 관광지가 될 것입니다.</string>
-    <string name="draft_feature_mountain00_text">이 작은 산은 관광객들에게 이 거이 평평한 땅의 관광지가 될 것입니다.</string>
+    <string name="draft_decosmallmountain00_text">이 작은 산은 관광객들에게 이 거의 평평한 땅의 관광지가 될 것입니다.</string>
+    <string name="draft_feature_mountain00_text">이 작은 산은 관광객들에게 이 거 평평한 땅의 관광지가 될 것입니다.</string>
     <string name="dialog_connect_title">이웃 도시와의 연결</string>
     <string name="dialog_connect_text">외부와의 연결을 설정하고 싶으신가요?</string>
     <string name="menu_hideui">UI 숨기기</string>


### PR DESCRIPTION
1002 ~ 3 ㅡ "거의" 를 "거이"로 잘못 쓴 맞춤법 오류 수정 (XNOTE)