### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1867,7 +1867,7 @@
     <string name="draft_coittower00_title">코이트 탑</string>
     <string name="draft_coittower00_text">코이트 추모 타워(Coit Memorial Tower)는 샌프란시스코에 지어진 64m 추모탑입니다. 5번의 샌프란시스코 대화제에서 순직한 소방관에게 헌정되었습니다. 이 배경 때문에 소방호스 노즐과 비슷하게 디자인 되었습니다.</string>
     <string name="draft_bankofamerica00_title">뱅크 오브 아메리카 센터</string>
-    <string name="draft_bankofamerica00_text">뱅크 오브 아메리카 센터(Bank of America Center)는 택사스 휴스턴에 지어진 237m의 뱅크 오브 아메리카 본관입니다. 이 은행이 별로 좋다곤 않지만 마천루 자체는 멋있는듯 합니다.</string>
+    <string name="draft_bankofamerica00_text">뱅크 오브 아메리카 센터(Bank of America Center)는 택사스 휴스턴에 지어진 237m의 뱅크 오브 아메리카 본관입니다. 이 은행이 별로 좋다고 할 순 없지만 마천루 자체는 멋있는듯 합니다.</string>
     <string name="draft_transamerica00_title">트렌스아메리카 피라미드</string>
     <string name="draft_transamerica00_text">트렌스아메리카 피라미드(The Transamerica Pyramid)는 샌프란시스코 경제지구에 1972년에 지어진 260m 마천루 입니다. 트랜스아메리카 본관이며 마치 피라미드를 연상케하는 삼각기둥구조가 이색적입니다.</string>
     <string name="draft_feature_landmarks05_text">미국 캘리포니아 샌프란시스코의 유명한 건물을 가지세요!</string>
@@ -1882,7 +1882,7 @@
     <string name="draft_halloween_pumpkin00_title">호박</string>
     <string name="draft_halloween_pumpkin00_text">할로윈이 다가옵니다! 모두들 호박을 좋아합니다, 그렇죠?</string>
     <string name="draft_halloween_tree00_title">죽은 나무</string>
-    <string name="draft_halloween_tree00_text">무서운 이야기에서 일반적으로 사용되는 으스스한 죽은 나무</string>
+    <string name="draft_halloween_tree00_text">귀신 이야기에서 일반적으로 사용되는 으스스한 죽은 나무</string>
     <string name="draft_feature_landmarks04_title">랜드마크 4번 팩</string>
     <string name="draft_feature_landmarks05_title">랜드마크 5번 팩</string>
     <string name="draft_marker_watermarkermarker_title">이 버전은 해킹되었습니다!</string>
@@ -1890,8 +1890,8 @@
     <string name="settings_dedicatedplugintexture">더많은 플러그인 공간 (재시작해야 합니다. 불안정 할 수 있습니다.)</string>
     <string name="draft_haunted_house00_title">귀신의집</string>
     <string name="draft_haunted_house00_text">보기에 위험해 보이는 오래된 저택입니다. 그것이 여기 살지도 모릅니다.</string>
-    <string name="notify_illness">전염병 유행이 일어났습니다, 즉시 행동을 취해야 합니다. 의사를 보네세요!</string>
-    <string name="notify_illnessnomedic">전염별 유행이 일어났고 우린 의사가 없습니다. 지금 당장 데려오세요!</string>
+    <string name="notify_illness">전염병 유행이 일어났습니다, 즉시 행동을 취해야 합니다. 의사를 보내세요!</string>
+    <string name="notify_illnessnomedic">전염병 유행이 일어났고 우린 의사가 없습니다. 지금 당장 데려오세요!</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ

--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1864,36 +1864,34 @@
     <string name="draft_gol_dead_title">콘웨이의 생명 게임</string>
     <string name="draft_gol_dead_text">생명게임 필드를 만드세요. 상태를 바꾸기 위해 타일 건설을 탭하세요. 기본상태는 죽음상태 입니다.</string>
 
+    <string name="draft_coittower00_title">코이트 탑</string>
+    <string name="draft_coittower00_text">코이트 추모 타워(Coit Memorial Tower)는 샌프란시스코에 지어진 64m 추모탑입니다. 5번의 샌프란시스코 대화제에서 순직한 소방관에게 헌정되었습니다. 이 배경 때문에 소방호스 노즐과 비슷하게 디자인 되었습니다.</string>
+    <string name="draft_bankofamerica00_title">뱅크 오브 아메리카 센터</string>
+    <string name="draft_bankofamerica00_text">뱅크 오브 아메리카 센터(Bank of America Center)는 택사스 휴스턴에 지어진 237m의 뱅크 오브 아메리카 본관입니다. 이 은행이 별로 좋다곤 않지만 마천루 자체는 멋있는듯 합니다.</string>
+    <string name="draft_transamerica00_title">트렌스아메리카 피라미드</string>
+    <string name="draft_transamerica00_text">트렌스아메리카 피라미드(The Transamerica Pyramid)는 샌프란시스코 경제지구에 1972년에 지어진 260m 마천루 입니다. 트랜스아메리카 본관이며 마치 피라미드를 연상케하는 삼각기둥구조가 이색적입니다.</string>
+    <string name="draft_feature_landmarks05_text">미국 캘리포니아 샌프란시스코의 유명한 건물을 가지세요!</string>
+    <string name="dialog_cemeteryclear_title">지금 정리하기</string>
+    <string name="dialog_cemeteryclear_text">여기 조금의 공간을 재사용 할 수 있을것 같군요.</string>
+    <string name="cemetery_cmdclear">지금 정리하기</string>
+    <string name="cemetery_clear">스와이프하여 약간의 공간 비우기.</string>
+    <string name="draft_cemetery00_text">화장한 돌아간 사람들이 모셔진 장소입니다. 삼가 고인의 명복을 빕니다.</string>
+    <string name="draft_crematory00_text">돌아간 사람들은 여기서 화장됩니다.</string>
+    <string name="notify_bodydisposal_needer00">시장님께, 고인을 모시기 위해 공동묘지를 지을 것을 촉구합니다.</string>
+    <string name="notify_bodydisposal_producer00">이 공동묘지에 자리가 없습니다. 정리하거나 새로운 화장장 혹은 공동묘지를 건설하세요.</string>
+    <string name="draft_halloween_pumpkin00_title">호박</string>
+    <string name="draft_halloween_pumpkin00_text">할로윈이 다가옵니다! 모두들 호박을 좋아합니다, 그렇죠?</string>
+    <string name="draft_halloween_tree00_title">죽은 나무</string>
+    <string name="draft_halloween_tree00_text">무서운 이야기에서 일반적으로 사용되는 으스스한 죽은 나무</string>
+    <string name="draft_feature_landmarks04_title">랜드마크 4번 팩</string>
+    <string name="draft_feature_landmarks05_title">랜드마크 5번 팩</string>
+    <string name="draft_marker_watermarkermarker_title">이 버전은 해킹되었습니다!</string>
 
-    <string name="draft_coittower00_title">Coit Memorial Tower</string>
-    <string name="draft_coittower00_text">Coit Memorial Tower was built in 1933 and was dedicated to the volunteer firemen who had died in San Francisco\'s five major fires.</string>
-    <string name="draft_bankofamerica00_title">Bank of America Center</string>
-    <string name="draft_bankofamerica00_text">Bank of America Center, is a 52-story 779 ft (237 m) skyscraper in San Francisco, California.</string>
-    <string name="draft_transamerica00_title">Transamerica Pyramid</string>
-    <string name="draft_transamerica00_text">The Transamerica Pyramid is a 260m skyscraper in San Francisco that was completed in 1972 and is the home of financial services companies.</string>
-    <string name="draft_feature_landmarks05_text">Get some famous buildings from San Francisco, CA.</string>
-    <string name="dialog_cemeteryclear_title">Clear now</string>
-    <string name="dialog_cemeteryclear_text">I think we can reuse some of the space here.</string>
-    <string name="cemetery_cmdclear">Clear now</string>
-    <string name="cemetery_clear">SWIPE to free up some space.</string>
-    <string name="draft_cemetery00_text">A place where the remains of dead people are buried. Rest in peace.</string>
-    <string name="draft_crematory00_text">Dead people are burnt here.</string>
-    <string name="notify_bodydisposal_needer00">Dear mayor, I urge you to build a cemetery to bury the deceased.</string>
-    <string name="notify_bodydisposal_producer00">There\'s no space left in this cemetery. Clean it up or build a new cemetery or crematory.</string>
-    <string name="draft_halloween_pumpkin00_title">Pumpkin</string>
-    <string name="draft_halloween_pumpkin00_text">Halloween is coming! Everyone loves pumpkins, right?</string>
-    <string name="draft_halloween_tree00_title">Dead tree</string>
-    <string name="draft_halloween_tree00_text">A spooky dead tree that is typically used in ghost stories.</string>
-    <string name="draft_feature_landmarks04_title">Landmarks V</string>
-    <string name="draft_feature_landmarks05_title">Landmarks VI</string>
-    <string name="draft_marker_watermarkermarker_title">THIS VERSION HAS BEEN HACKED!</string>
-
-
-    <string name="settings_dedicatedplugintexture">More plugin texture space (needs a restart; may be unstable)</string>
-    <string name="draft_haunted_house00_title">Haunted house</string>
-    <string name="draft_haunted_house00_text">An old mansion that looks dangerous. IT might live here.</string>
-    <string name="notify_illness">There\'s an epidemic outbreak, we have to take action immediately. Send the doctor!</string>
-    <string name="notify_illnessnomedic">There\'s an epidemic outbreak and we have no doctor. Get one NOW!</string>
+    <string name="settings_dedicatedplugintexture">더많은 플러그인 공간 (재시작해야 합니다. 불안정 할 수 있습니다.)</string>
+    <string name="draft_haunted_house00_title">귀신의집</string>
+    <string name="draft_haunted_house00_text">보기에 위험해 보이는 오래된 저택입니다. 그것이 여기 살지도 모릅니다.</string>
+    <string name="notify_illness">전염병 유행이 일어났습니다, 즉시 행동을 취해야 합니다. 의사를 보네세요!</string>
+    <string name="notify_illnessnomedic">전염별 유행이 일어났고 우린 의사가 없습니다. 지금 당장 데려오세요!</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
1873~9 ㅡ 무덤을... 치운다고 하기엔 한국정서에 너무 않맞죠. 정리한다로 대체번역 하겠습니다.
1879 ㅡ 사람을 태우진 않죠.
1878 ㅡ 죽인 사람에 대해선 예를 갖추어야 한다고 생각하는데, 잘 않되네요. 적절한 번역 필히 수용합니다.
1885 ㅡ 딱히 ghost story 를 번역하기 애매했습니다. 그래서 "무서운 이야기"로 번역하였으나, "괴담" 사용도 검토중입니다.
1894 ㅡ 원문 "Get one NOW" 의 의미는 "지금 당장 가져와" 입니다. 하지만 불특정 사람에게 "가져와"를 쓰는 것은 예의에 어긋난다고 할 수 있습니다.  따라서 대체번역인 "지금 당장 데려오세요" 라고 하였습니다.