### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1893,21 +1893,20 @@
     <string name="notify_illness">전염병 유행이 일어났습니다, 즉시 행동을 취해야 합니다. 의사를 보내세요!</string>
     <string name="notify_illnessnomedic">전염병 유행이 일어났고 우린 의사가 없습니다. 지금 당장 데려오세요!</string>
 
-
-    <string name="shader_lol">LOL</string>
-    <string name="settings_hugeplugintexture">Congratulations, you\'re running in huge texture mode.</string>
-    <string name="draft_tree00_autumn00_title">Autumn trees</string>
-    <string name="draft_tree00_autumn00_text">Withering leaves can be so beautiful.</string>
-    <string name="settings_handintoolbar">Show hand in toolbar</string>
-    <string name="draft_bushman00_title">Statue of bushman</string>
-    <string name="draft_bushman00_text">\"Mum, what is that?\"\n\"Don\'t look at it. Otherwise it will haunt you in your dreams.\"</string>
-    <string name="draft_police03_title">Modern police dep.</string>
-    <string name="draft_police03_text">Put some money into it and you\'ll be able to solve any issues with crime.</string>
-    <string name="draft_sf_cityhall00_title">City hall</string>
-    <string name="draft_sf_cityhall00_text">A city hall inspired by the city hall in San Francisco.</string>
-    <string name="draft_sf_fineartspalace00_title">Palace of Fine Arts</string>
-    <string name="draft_sf_fineartspalace00_text">The Palace of Fine Arts of San Francisco, California, is a monumental structure originally constructed for the 1915 Panama-Pacific Exposition.</string>
-    <string name="shader_invert">Inverted</string>
+    <string name="shader_lol">ㅋㅋㅋ</string>
+    <string name="settings_hugeplugintexture">축하드립니다, 대용량 텍스쳐 모드로 실행중입니다.</string>
+    <string name="draft_tree00_autumn00_title">가을 나무</string>
+    <string name="draft_tree00_autumn00_text">시든 나뭇잎도 아름다워질 수 있습니다..</string>
+    <string name="settings_handintoolbar">툴바에서 손 보이기</string>
+    <string name="draft_bushman00_title">코이산족 동상</string>
+    <string name="draft_bushman00_text">\"음, 그게 뭔가요?\"\n\"처다보지마세요. 그렇지 않으면 꿈속에서 당신을 괴롭힐 겁니다.\"</string>
+    <string name="draft_police03_title">현대식 경찰서</string>
+    <string name="draft_police03_text">시 재정을 투자하세요. 그러면 어떤 범죄 사건도 해결할 수 있게 될 것입니다.</string>
+    <string name="draft_sf_cityhall00_title">시청</string>
+    <string name="draft_sf_cityhall00_text">샌프란시스코시청에서 영감받아 만든 시청.</string>
+    <string name="draft_sf_fineartspalace00_title">미술의 궁전</string>
+    <string name="draft_sf_fineartspalace00_text">미술의 궁전(The Palace of Fine Arts)은 캘리포니아 샌프란시스코에 위치하는, 1915년 파나마-태평양 박람회 당시 사용된 전시관 중 하나입니다.</string>
+    <string name="shader_invert">색 반전으로 보기</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
1899 ㅡ 원문은 "Withering leaves can be so beautiful" 이며, 동명사 형태로써 "시든 나뭇잎"이라 해석하였습니다.
1901~2 ㅡ 부시맨(bushman)은 코이산족의 이명입니다. (https://namu.wiki/w/%EC%BD%94%EC%9D%B4%EC%82%B0%EC%A1%B1)
1904 ㅡ 기존의 "money"는 문맥에 맞도록 "시 재정"으로, "and"는 한국어 어감에 호응하지 않아 2개의 문장으로 분리시켜 처리하였습니다.
1906 ㅡ 원문에 "만들었다"는 없으나, 어감이 좋지 않아 추가하였습니다.
1907 ㅡ 공식 한국어 번역이 없는 건축물 입니다.