### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1957,20 +1957,18 @@
     <string name="dialog_storereported_title">플러그인이 보고되었습니다.</string>
     <string name="dialog_storereported_text">피드백 해주셔서 감사합니다! 저희는 이 플러그인을 검토하고 적절한 조치를 취할 것입니다.</string>
 
+    <string name="store_ratings">평점 %,d</string>
+    <string name="store_loadingerror">에러</string>
+    <string name="dialog_storeerror_title">로딩 에러</string>
+    <string name="dialog_storeerror_text">이 플러그인은 다음의 이유 때문에 로딩될 수 없었습니다.:</string>
+    <string name="store_new">신작 . 업데이트</string>
+    <string name="draft_cat_plugins00_title">플러그인</string>
+    <string name="dialog_storesearch_title">플러그인 검색</string>
+    <string name="dialog_storesearch_text">키워드를 입력하세요:</string>
+    <string name="dialog_storesearch_cmdsearch">검색</string>
 
-    <string name="store_ratings">by %,d ratings</string>
-    <string name="store_loadingerror">Error</string>
-    <string name="dialog_storeerror_title">Loading error</string>
-    <string name="dialog_storeerror_text">This plugin could not be loaded for the following reason:</string>
-    <string name="store_new">New and Updated</string>
-    <string name="draft_cat_plugins00_title">Plugins</string>
-    <string name="dialog_storesearch_title">Search plugin</string>
-    <string name="dialog_storesearch_text">Enter a keyword below:</string>
-    <string name="dialog_storesearch_cmdsearch">Search</string>
-
-
-    <string name="draft_deco_chr_santashouse00_title">Santa\'s House</string>
-    <string name="draft_deco_chr_santashouse00_text">Santa uses it as a base to distribute presents.</string>
+    <string name="draft_deco_chr_santashouse00_title">산타의 집</string>
+    <string name="draft_deco_chr_santashouse00_text">산타 할아버지는 이곳을 선물을 나누어주기 위한 베이스로 사용합니다.</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ


### PR DESCRIPTION
1964 - "그리고"를 사용하기엔 어감이 너무 이상해서 분리시켰습니다.