### PR TITLE
Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -2075,46 +2075,46 @@
     <string name="settings_fontscaling_big">큼</string>
     <string name="pluginerror_disable">해제</string>
 
-
-    <string name="music_next">Next music</string>
-    <string name="createcity_generating">Generating City</string>
-    <string name="dialog_notenoughmoneyp_title">Insufficient funds</string>
-    <string name="dialog_notenoughmoneyp_text">We have not enough money to buy this right now :(</string>
-    <string name="game_region">Region %1$d/%2$d</string>
-    <string name="gamemode_sandbox_title">Sandbox</string>
-    <string name="gamemode_sandbox_text">Use this mode for experiments without money. Your inhabitants still have needs that you have to fulfill.</string>
-    <string name="dialog_ubermode_title">Uber Mode</string>
+    <string name="music_next">다음 브금</string>
+    <string name="createcity_generating">도시 생성</string>
+    <string name="dialog_notenoughmoneyp_title">부족한 재정</string>
+    <string name="dialog_notenoughmoneyp_text">이것을 바로 하기위한 돈이 충분치 않습니다 :(</string>
+    <string name="game_region">지역 %1$d/%2$d</string>
+    <string name="gamemode_sandbox_title">샌드박스</string>
+    <string name="gamemode_sandbox_text">비용없이 여러가지를 실험하기 위한 모드입니다. Your inhabitants still have needs that you have to fulfill.</string>
+    <string name="dialog_ubermode_title">우버 모드</string>
     <string name="dialog_ubermode_text">Enable this special mode to get rid of all the hassle in the city:\n-No fires\n-No garbage\n-No diseases\n-No crimes\n-No deaths\n-Full education\n-100% popularity</string>
-    <string name="topic_pluginsawesome">Plugins are awesome! However, we recommend to disable unused plugins.</string>
-    <string name="topic_platforms">Did you know that TheoTown is available for PC, Android and iOS?</string>
-    <string name="topic_pluginspace">Plugin space is limited, keep that in mind</string>
-    <string name="topic_rotate">Did you know that you can rotate your city?</string>
-    <string name="topic_pineapple">Pineapple on pizza?</string>
-    <string name="topic_f11">Press F11 to activate fullscreen mode</string>
-    <string name="draft_permanent_snow00_title">Snow</string>
-    <string name="draft_permanent_snow00_text">There\'s always winter at this place.</string>
-    <string name="settings_hidelabels">Hide labels</string>
-    <string name="settings_sound_ambient">Ambient</string>
+    <string name="topic_pluginsawesome">플러그인은 멋있습니다! 그러나, 않쓰는 플러그인은 해제하길 바랍니다.</string>
+    <string name="topic_platforms">데오타운을 PC, 안드로이드, iOS에서도 할 수 있다는걸 아시나요?</string>
+    <string name="topic_pluginspace">플러그인 용량은 제한되어 있습니다, 염두해두세요</string>
+    <string name="topic_rotate">도시가 회전이 가능하다는 것을 알고 계시나요?</string>
+    <string name="topic_pineapple">민트초코?</string>
+    <string name="topic_f11">F11 로 전체화면</string>
+    <string name="draft_permanent_snow00_title">눈</string>
+    <string name="draft_permanent_snow00_text">이 장소는 언재나 겨울입니다.</string>
+    <string name="settings_hidelabels">라벨 숨기기</string>
+    <string name="settings_sound_ambient">주변 환경</string>
     <string name="settings_vsync">VSync</string>
 
 </resources><!--
 ㅡ한글 번역에 대한 안내ㅡ
 1. 업데이트 로그 양식은 다음과 같이 해주세요.
- ㄱ. 제목
-   a. 한글 번역 업데이트 / Korean translation Update
-   b. 한글 맞춤법 수정 / Update about Korean grammar
-   c. 오타 수정 / Fix typo
-   d. 부가 번역 / Addition
+ ㄱ. 제목 (뒤의 영어만 사용)
+   a. 한글 번역 업데이트    / Korean translation Update
+   b. 한글 맞춤법/문법 수정 / Grammar fix
+   c. 부가 번역            / Addition
  ㄴ. 내용
    a. 수정 문장 줄 ㅡ 자세한 수정 내용
    b. 만일 번역에 확신이 들지 않는다면, 해당 사항을 수정 내용에 반드시 명시해주세요.
    c. 부가 번역에 대해서는 이미 pull request를 한 경우 사용해 주시기바랍니다.
-2. 현재 작업중 내용은 다음과 같습니다.
- ㄱ. 이것을 다른 적절한 어휘로 대체.
- ㄴ. 번역물에 대한 어감 수정.
-3. 기타 주의사항
+2. 번역의 방향은 아래와 같습니다.
+ ㄱ. 의미상 부적절한 어휘 수정
+3. 주의사항
  ㄱ. 번역후 반드시 Create pull request를 하시기 바랍니다. 왜냐하면 번역물이 Merged 돼야 본 게임에 적용되기 때문입니다.
  ㄴ. 최대한 원문에 충실 한 번역을 해주세요. 왜냐하면 원작자의 의견이 최대한 반영되어야 한다고 생각되기 때문입니다.
  ㄷ. 이 문서는 xml문서입니다. 파일을 읽어 들이는 데에 필요한 부분을 수정하지 않도록 주의하시기 바랍니다. 슬래쉬 등의 문자 또한 사용에 주의하시기 바랍니다.
  ㄹ. dialog 내용에 대해서 의문이 드신다면 네이버 카페 게시글을 참고하시기 바랍니다.
+4. 기타 정보
+ ㄱ. 번역 문구에 대한 문의는 카카오톡 yvelkram 을 통해 해주시기 바랍니다.
+ ㄴ. 부득이하게 번역을 더이상 진행할 수 없을경우, 반드시 인수인계를 해주시기 바랍니다.
 -->


### PR DESCRIPTION
2083 ㅡ "sandbox" 는 기술용어이기 때문에 원어를 사용했습니다.
2084 ㅡ 첫부분의 "Using" 의역,
2085 ㅡ 독일어 원어인 "über"인데, 의미는 "초-, 극-"과 비슷합니다. 다만, 도저히 괜찮은 어휘가 없어서 굳이 번역하지 않겠습니다.
2091 ㅡ 외국하고 한국에서 유행했던 "파인애플피자" 인데, 한국에서 그렇게 유명하다고 생각되진 않으므로 비슷한 주제인 "민트초코"로 대체합니다.
2097 ㅡ 기술 용어이기 때문에 번역하지 않습니다.

2100~ ㅡ  I have changed that translation feedback is only accepted via Github or Kakaotalk, So, update translation info section.