### PR TITLE
Fixed translation

### DIFF
--- a/values-lt/strings.xml
+++ b/values-lt/strings.xml
@@ -60,7 +60,7 @@
     <string name="dialog_screenshot_text">Ši nuotrauka buvo išsaugota šiuo pavadinimu %1$s.</string>
     <string name="dialog_screenshot_cmdok">Gerai, ačiū</string>
     <string name="draftselector_titleparks">Parkai</string>
-    <string name="draftselector_titlepublics">Viešieji pastatai</string>
+    <string name="draftselector_titlepublics">Vieši</string>
     <string name="draftselector_titleenergy">Energija</string>
     <string name="draftselector_titlewater">Vanduo</string>
     <string name="draftselector_titleschool">Švietimas</string>
@@ -183,7 +183,7 @@
     <string name="budget_award">Apdovanojimai</string>
     <string name="budget_energy">Energija</string>
     <string name="budget_water">Vanduo</string>
-    <string name="budget_public">Viešieji pastatai</string>
+    <string name="budget_public">Vieši</string>
     <string name="budget_medic">Gydymas</string>
     <string name="ci_budget_overall">Iš viso</string>
     <string name="ci_budget_income">Uždarbis (per mėnesį)</string>

--- a/values-lt/strings.xml
+++ b/values-lt/strings.xml
@@ -100,8 +100,8 @@
     <string name="draft_windturbine00_text">Vėjo jėgainė skleidžia garsą, bet neskleidžia teršalų.</string>
     <string name="draft_coalplant00_title">Anglies elektrinė</string>
     <string name="draft_coalplant00_text">Anglies elektrinės pagamina daug energijos, tačiau daro blogą įtaką aplinkai.</string>
-    <string name="draft_solarpanels00_title">Saulės elementai</string>
-    <string name="draft_solarpanels00_text">Saulės elemantai yra geri aplinkai ir jie neteršia aplinkos.</string>
+    <string name="draft_solarpanels00_title">Saulės baterijos</string>
+    <string name="draft_solarpanels00_text">Saulės baterijos yra geros aplinkai ir jie neteršia aplinkos.</string>
     <string name="draft_park00_title">Mažas gėlių parkas</string>
     <string name="draft_park00_text">Gyventojams tai patiks.</string>
     <string name="draft_park01_title">Mažas parkas</string>


### PR DESCRIPTION
The correct translation for solar panels is "Saulės baterijos" not "Saulės elementai"