### PR TITLE
Resolution fix and minor changes on the vocabulary

### DIFF
--- a/values-es/strings.xml
+++ b/values-es/strings.xml
@@ -22,18 +22,18 @@
     <string name="game_habitants">Habitantes: %1$,d</string>
     <string name="game_cityname">%1$s</string>
     <string name="createcity_seed">Semilla:</string>
-    <string name="createcity_sizesmall">Pequeño</string>
-    <string name="createcity_sizemiddle">Mediano</string>
+    <string name="createcity_sizesmall">Pequeña</string>
+    <string name="createcity_sizemiddle">Mediana</string>
     <string name="createcity_sizebig">Grande</string>
     <string name="createcity_sizeother">Otro</string>
     <string name="game_monthlyincome">%1$,+d</string>
     <string name="game_estate">Estado: %1$s</string>
     <string name="game_rating">%1$,d</string>
-    <string name="settings_resolutionlowlow">Muy bajo</string>
-    <string name="settings_resolutionlow">Bajo</string>
+    <string name="settings_resolutionlowlow">Muy baja</string>
+    <string name="settings_resolutionlow">Baja</string>
     <string name="settings_resolutionnormal">Normal</string>
-    <string name="settings_resolutionbig">Grande</string>
-    <string name="settings_resolutionbigbig">Muy grande</string>
+    <string name="settings_resolutionbig">Alta</string>
+    <string name="settings_resolutionbigbig">Muy alta</string>
     <string name="settings_resolution">Resolución</string>
     <string name="dialog_nocities_title">No hay ciudades</string>
     <string name="dialog_nocities_text">No se puede encontrar ninguna ciudad.</string>
@@ -45,10 +45,10 @@
     <string name="settings_transparencybuildmode">Trasparencia en el modo de construcción</string>
     <string name="settings_buildgrid">Rejilla en modo de construcción</string>
     <string name="settings_doublecardrawing">Ver coches dobles</string>
-    <string name="settings_drawwatersparkle">Ver chispas de agua</string>
+    <string name="settings_drawwatersparkle">Ver salpicaduras de agua</string>
     <string name="settings_drawmapedges">Dibujar bordes del mapa</string>
     <string name="settings_hideads_title">Quitar anuncios</string>
-    <string name="settings_hideads_text">Si realmente desea quitar los anuncios, sería bueno que nos apoyara diciéndole a sus amigos sobre la aplicación.
+    <string name="settings_hideads_text">Si realmente desea quitar los anuncios, agradeceríamos que nos apoyara diciéndole a sus amigos sobre la aplicación.
 
 \n\n¿Estás seguro?</string>
     <string name="settings_hideads_yes">Estoy seguro</string>


### PR DESCRIPTION
The resolution and city in spanish is on female so instead of ''bajo'' and ''muy bajo'' it would be ''baja'' and ''muy baja'' and instead of ''pequeño'' and ''mediano'' it would be ''pequeña'' and ''mediana'', furthermore the adjective for resolution is ''alta'' and not ''grande'' although I must say it was perfectly understandable before the correction it more correct now. Some words seemed weird so I changed them :3.