### PR TITLE
Small line break update for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Every directory contains a `values.xml` file. The corresponding languages are:
 - values-uk: Ukrainian
 - values-zh-rTW: Traditional Chinese
 - values-zh: Chinese
-- values: English (*default language*) <-- **Always up to date**
+- values: English (*default language*) <-- **Always up to date**<br/>
 
 For more two letter language codes see [ISO 639-1](http://www.loc.gov/standards/iso639-2/php/code_list.php). You might just add an apropriate directory in order to add a new language. English and German translations *will always be up to date*. The others can be built from them.
 
 ---
 
 ## How translation works:
-Each `values.xml` file contains lines of the form:
-`<tagname>"My translation"</tagname>`
+Each `values.xml` file contains lines of the form:<br/>
+`<tagname>"My translation"</tagname>`<br/>
 You have just to translate the part in between (here "My Translation"). Special characters like `\n` might be used to indicate a new line. When your translation is done, **make sure to create a 'pull request'** so it can be merged to main branch. If you forget to do that step your translation won't be added to the main branch.


### PR DESCRIPTION
"How translation works" was missing some line breaks